### PR TITLE
ticket 1 : authentification

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,7 +20,7 @@ jobs:
             const match = branch.match(/^(\d+)-/);
             if (!match) return;
 
-            const issueNumber = parseInt(match[1])+1;
+            const issueNumber = parseInt(match[1]);
             const issue = await github.rest.issues.get({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
   <NConfigProvider>
     <NMessageProvider>
       <NLayout>
-        <HeaderBar />
+        <HeaderBar v-if="authStore.isAuthenticated" />
         <NLayoutContent>
           <RouterView />
         </NLayoutContent>
@@ -12,7 +12,11 @@
 </template>
 
 <script setup lang="ts">
+import { useAuthStore } from '@/stores/auth.store'
+
 import HeaderBar from './components/layout/HeaderBar.vue'
+
+const authStore = useAuthStore()
 </script>
 
 <style>

--- a/src/components/layout/HeaderBar.vue
+++ b/src/components/layout/HeaderBar.vue
@@ -26,13 +26,25 @@
         </NButton>
       </NSpace>
       <NSpace align="center" :size="16">
-        <NText depth="3">Renseigner le user connecté ici</NText>
-        <NButton size="small">Déconnexion</NButton>
+        <NText depth="3">{{ authStore.user?.username }}</NText>
+        <NButton size="small" @click="handleSignOut">Déconnexion</NButton>
       </NSpace>
     </NSpace>
   </NLayoutHeader>
 </template>
 
 <script setup lang="ts">
+import { useRouter } from 'vue-router'
+
+import { ROUTES } from '@/router'
+import { useAuthStore } from '@/stores/auth.store'
+
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL as string
+const authStore = useAuthStore()
+const router = useRouter()
+
+const handleSignOut = async () => {
+  authStore.signOut()
+  await router.push(ROUTES.SIGN_IN)
+}
 </script>

--- a/src/pages/SignIn.vue
+++ b/src/pages/SignIn.vue
@@ -1,0 +1,95 @@
+<template>
+  <NForm @submit.prevent="handleSignIn">
+    <NFormItem label="Email" required style="width: 100%">
+      <NInput v-model:value="email" round type="text" placeholder="Email" />
+    </NFormItem>
+
+    <NFormItem label="Mot de passe" required style="width: 100%">
+      <NInput
+        v-model:value="password"
+        round
+        type="password"
+        show-password-on="mousedown"
+        placeholder="Password"
+      />
+    </NFormItem>
+
+    <NButton
+      type="primary"
+      round
+      attr-type="submit"
+      style="width: 100%"
+      :loading="loading"
+      :disabled="loading"
+    >
+      Se connecter
+    </NButton>
+
+    <p v-if="errorMessage" class="error">{{ errorMessage }}</p>
+
+    <div class="footer">
+      <p>
+        Pas encore de compte ?
+        <RouterLink :to="ROUTES.SIGN_UP"><span>S'inscrire</span></RouterLink>
+      </p>
+    </div>
+  </NForm>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+import { ROUTES } from '@/router'
+import { useAuthStore } from '@/stores/auth.store'
+
+const authStore = useAuthStore()
+const router = useRouter()
+
+const email = ref('')
+const password = ref('')
+const loading = ref(false)
+const errorMessage = ref('')
+
+const handleSignIn = async () => {
+  if (loading.value) return
+
+  loading.value = true
+  errorMessage.value = ''
+
+  try {
+    await authStore.signIn({
+      email: email.value,
+      password: password.value,
+    })
+    await router.push(ROUTES.HOME)
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Identifiants incorrects'
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<style scoped>
+.footer {
+  display: flex;
+  justify-content: center;
+}
+
+.footer span {
+  text-decoration: none;
+  transition: all 0.3s;
+}
+
+.footer span:hover {
+  color: violet;
+}
+
+.error {
+  margin-top: 8px;
+  color: #d03050;
+  text-align: center;
+}
+</style>

--- a/src/pages/SignUp.vue
+++ b/src/pages/SignUp.vue
@@ -1,0 +1,100 @@
+<template>
+  <NForm @submit.prevent="handleSignUp">
+    <NFormItem label="Nom utilisateur" required style="width: 100%">
+      <NInput
+        v-model:value="username"
+        round
+        type="text"
+        placeholder="Nom de l'utilisateur"
+      />
+    </NFormItem>
+    <NFormItem label="Email" required style="width: 100%">
+      <NInput v-model:value="email" round type="text" placeholder="Email" />
+    </NFormItem>
+    <NFormItem label="Mot de passe" required style="width: 100%">
+      <NInput
+        v-model:value="password"
+        round
+        type="password"
+        show-password-on="mousedown"
+        placeholder="Password"
+      />
+    </NFormItem>
+    <NButton
+      type="primary"
+      round
+      attr-type="submit"
+      style="width: 100%"
+      :loading="loading"
+      :disabled="loading"
+      >S'inscrire</NButton
+    >
+
+    <p v-if="errorMessage" class="error">{{ errorMessage }}</p>
+
+    <div class="footer">
+      <p>
+        Déjà un compte ?
+        <RouterLink :to="ROUTES.SIGN_IN"><span>Se connecter</span></RouterLink>
+      </p>
+    </div>
+  </NForm>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+import { ROUTES } from '@/router'
+import { useAuthStore } from '@/stores/auth.store'
+
+const authStore = useAuthStore()
+const router = useRouter()
+
+const username = ref('')
+const email = ref('')
+const password = ref('')
+const loading = ref(false)
+const errorMessage = ref('')
+
+const handleSignUp = async () => {
+  if (loading.value) return
+
+  loading.value = true
+  errorMessage.value = ''
+
+  try {
+    await authStore.signUp({
+      username: username.value,
+      email: email.value,
+      password: password.value,
+    })
+    await router.push(ROUTES.HOME)
+  } catch (error) {
+    errorMessage.value =
+      error instanceof Error ? error.message : "Erreur lors de l'inscription"
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+<style scoped>
+.footer {
+  display: flex;
+  justify-content: center;
+}
+
+.footer span {
+  text-decoration: none;
+  transition: all 0.3s;
+}
+.footer span:hover {
+  color: violet;
+}
+
+.error {
+  margin-top: 8px;
+  color: #d03050;
+  text-align: center;
+}
+</style>

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,18 +1,40 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
+import { useAuthStore } from '@/stores/auth.store'
+
 import HomePage from './pages/HomePage.vue'
+import SignInPage from './pages/SignIn.vue'
+import SignUpPage from './pages/SignUp.vue'
 
 export const ROUTES = {
   HOME: '/',
+  SIGN_IN: '/sign-in',
+  SIGN_UP: '/sign-up',
 } as const
 
 const routes = [
   { path: ROUTES.HOME, component: HomePage, meta: { requiresAuth: true } },
+  { path: ROUTES.SIGN_IN, component: SignInPage, meta: { guestOnly: true } },
+  { path: ROUTES.SIGN_UP, component: SignUpPage, meta: { guestOnly: true } },
 ]
 
 const router = createRouter({
   history: createWebHistory(),
   routes,
+})
+
+router.beforeEach((to) => {
+  const authStore = useAuthStore()
+
+  if (to.meta.requiresAuth && !authStore.isAuthenticated) {
+    return ROUTES.SIGN_IN
+  }
+
+  if (to.meta.guestOnly && authStore.isAuthenticated) {
+    return ROUTES.HOME
+  }
+
+  return true
 })
 
 export default router

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -1,0 +1,53 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { computed } from 'vue'
+
+import { useApi } from '@/composables/useApi'
+import { useStorage } from '@/composables/useStorage'
+import type { User } from '@/types'
+
+import type { SignInPayload, SignUpPayload } from './../types/auth'
+
+export const useAuthStore = defineStore('auth', () => {
+  const { get, set, remove } = useStorage()
+  const useAPI = useApi()
+  const token = ref(get<string>('token'))
+  const user = ref(get<User>('user'))
+
+  const isAuthenticated = computed((): boolean => {
+    return token.value && user.value ? true : false
+  })
+
+  const signUp = async (payload: SignUpPayload) => {
+    const { username, email, password } = payload
+    const response = await useAPI.signUp({
+      username: username,
+      email: email,
+      password: password,
+    })
+    set('token', response.token)
+    set('user', response.user)
+    token.value = response.token
+    user.value = response.user
+  }
+
+  const signIn = async (payload: SignInPayload) => {
+    const { email, password } = payload
+    const response = await useAPI.signIn({
+      email: email,
+      password: password,
+    })
+    set('token', response.token)
+    set('user', response.user)
+    token.value = response.token
+    user.value = response.user
+  }
+
+  const signOut = () => {
+    remove('token', 'user')
+    token.value = null
+    user.value = null
+  }
+
+  return { token, user, isAuthenticated, signUp, signIn, signOut }
+})


### PR DESCRIPTION
> Contenu de l'issue [#2 — 1. Authentification (3 pts)](https://github.com/remyrampelberghe/Pokemon_vue/issues/2)

Mettre en place le système d'authentification complet : store, guards de navigation et pages de connexion/inscription.

> 🎨 [Voir les maquettes sur Figma](https://making-rerun-61323218.figma.site/)

---

## Store d'authentification

L'application doit gérer un état de connexion global, persisté entre les rechargements de page. Cet état contient le token JWT et les informations de l'utilisateur connecté.

La navigation doit être protégée : un utilisateur non connecté est redirigé vers la page de connexion s'il tente d'accéder à une route privée, et un utilisateur déjà connecté ne peut pas accéder aux pages de connexion ou d'inscription. La barre de navigation n'est visible que pour les utilisateurs connectés.

> La protection des routes implique également de modifier le fichier `router.ts` en y ajoutant un router guard.



### Règles de gestion

| #   | Règle                                                                                           |
| --- | ----------------------------------------------------------------------------------------------- |
| RG1 | L'état de connexion (token + informations utilisateur) est persisté et restauré au rechargement |
| RG2 | Toute route privée redirige vers la page de connexion si l'utilisateur n'est pas authentifié    |
| RG3 | Les pages de connexion et d'inscription sont inaccessibles si l'utilisateur est déjà connecté   |
| RG4 | La barre de navigation n'est affichée que si l'utilisateur est connecté                         |
| RG5 | La barre de navigation affiche le nom d'utilisateur connecté                                    |
| RG6 | La barre de navigation propose un bouton de déconnexion qui redirige vers la page de connexion  |

---

## Page de connexion

Page accessible aux utilisateurs non connectés. L'utilisateur saisit son email et son mot de passe. En cas de succès, il est redirigé vers la page d'accueil (`/`). En cas d'échec, un message d'erreur s'affiche. Un lien permet d'accéder à la page d'inscription.


### Règles de gestion

| #   | Règle                                                                     |
| --- | ------------------------------------------------------------------------- |
| RG1 | Le formulaire contient les champs email et mot de passe                   |
| RG2 | Le bouton de soumission est désactivé pendant l'appel à l'API             |
| RG3 | Un message d'erreur s'affiche si les identifiants sont incorrects         |
| RG4 | L'utilisateur est redirigé vers la page d'accueil après connexion réussie |
| RG5 | Un lien vers la page d'inscription est visible                            |

---

## Page d'inscription

Page accessible aux utilisateurs non connectés. L'utilisateur saisit un nom d'utilisateur, un email et un mot de passe. En cas de succès, il est redirigé vers la page d'accueil (`/`). En cas d'échec (ex. email déjà utilisé), un message d'erreur s'affiche. Un lien permet d'accéder à la page de connexion.


### Règles de gestion

| #   | Règle                                                                       |
| --- | --------------------------------------------------------------------------- |
| RG1 | Le formulaire contient les champs username, email et mot de passe           |
| RG2 | Le bouton de soumission est désactivé pendant l'appel à l'API               |
| RG3 | Un message d'erreur s'affiche en cas d'échec de l'inscription               |
| RG4 | L'utilisateur est redirigé vers la page d'accueil après inscription réussie |
| RG5 | Un lien vers la page de connexion est visible                               |

---

---

Closes #2